### PR TITLE
Fix for zooming in further especially on iPad

### DIFF
--- a/Pod/Classes/SwiftPhotoGalleryCell.swift
+++ b/Pod/Classes/SwiftPhotoGalleryCell.swift
@@ -148,6 +148,7 @@ open class SwiftPhotoGalleryCell: UICollectionViewCell {
         let heightScale = scrollViewSize.height / imageViewSize.height
 
         scrollView.minimumZoomScale = min(widthScale, heightScale)
+        scrollView.maximumZoomScale = UIDevice.current.userInterfaceIdiom == .pad ? 4 : 3
         scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
     }
     


### PR DESCRIPTION
Currently, on iPad you cannot zoom in past a certain small amount. This is especially noticeable in landscape mode. This will allow further zooming for iPads and iPhones in various orientations.