### PR TITLE
Fixed iPad multitasking issue

### DIFF
--- a/Pod/Classes/SwiftPhotoGallery.swift
+++ b/Pod/Classes/SwiftPhotoGallery.swift
@@ -443,12 +443,12 @@ extension SwiftPhotoGallery: UICollectionViewDataSource {
 
     @objc public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         guard isRevolvingCarouselEnabled else { return CGSize.zero }
-        return CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+        return view.frame.size
     }
 
     @objc public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         guard isRevolvingCarouselEnabled else { return CGSize.zero }
-        return CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+        return view.frame.size
     }
 }
 


### PR DESCRIPTION
When gallery view runs on iPad with multitasking enabled, the image is not placed in centre.
Because the size of header and footer was set to screen size which doesn't equal view size in multitasking mode.